### PR TITLE
[RND-342] Adding action to run auditor

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
     paths:
-      - '.github'
+      - '.github/**'
 
 jobs:
   scan-actions:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: Review
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github'
+
+jobs:
+  scan-actions:
+    name: Scan Actions
+    uses: ed-fi-alliance-oss/ed-fi-actions/.github/workflows/repository-scanner.yml@latest

--- a/.github/workflows/run-full-audit.yml
+++ b/.github/workflows/run-full-audit.yml
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: Run Full Audit
+on:
+  workflow_dispatch:
+  schedule:
+    # Audit on Friday at 5:00 p.m.
+    # - cron: '0 17 * * 5'
+    - cron: '0 7 * * 3'
+
+env:
+  PERSONAL_ACCESS_TOKEN: ${{ secrets.EDFI_BUILD_AGENT_PAT }}
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+  security-events: write
+
+jobs:
+  audit:
+    name: Audit Ed-Fi Organizations
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        org: [Ed-Fi-Exchange-OSS, Ed-Fi-Alliance-OSS, Ed-Fi-Closed]
+    defaults:
+      run:
+        working-directory: edfi-repo-auditor
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install Python 3.9
+        uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6 # v3.1.2
+        with:
+          python-version: "3.9"
+          cache: "poetry"
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Audit ${{ matrix.org }}
+        run: poetry run python edfi_repo_auditor -p ${{ env.PERSONAL_ACCESS_TOKEN }} -s -o ${{ matrix.org }}  -f ${{ matrix.org }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
+        with:
+          name: audit-result
+          path: ./edfi-repo-auditor/reports/**.json
+          if-no-files-found: error
+          retention-days: 10

--- a/.github/workflows/run-full-audit.yml
+++ b/.github/workflows/run-full-audit.yml
@@ -8,8 +8,7 @@ on:
   workflow_dispatch:
   schedule:
     # Audit on Friday at 5:00 p.m.
-    # - cron: '0 17 * * 5'
-    - cron: '0 7 * * 3'
+    - cron: '0 17 * * 5'
 
 env:
   PERSONAL_ACCESS_TOKEN: ${{ secrets.EDFI_BUILD_AGENT_PAT }}

--- a/.github/workflows/run-full-audit.yml
+++ b/.github/workflows/run-full-audit.yml
@@ -51,7 +51,7 @@ jobs:
         run: poetry run python edfi_repo_auditor -p ${{ env.PERSONAL_ACCESS_TOKEN }} -s -o ${{ matrix.org }}  -f ${{ matrix.org }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: audit-result
           path: ./edfi-repo-auditor/reports/**.json

--- a/.github/workflows/run-single-audit.yml
+++ b/.github/workflows/run-single-audit.yml
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: Run Single Audit
+on:
+  workflow_dispatch:
+    inputs:
+      organization:
+        type: choice
+        description: Organization
+        options:
+        - Ed-Fi-Exchange-OSS
+        - Ed-Fi-Alliance-OSS
+        - Ed-Fi-Closed
+        required: true
+      repository:
+        type: string
+        description: Name of repository to analyze
+        default: ''
+        required: false
+
+env:
+  PERSONAL_ACCESS_TOKEN: ${{ secrets.EDFI_BUILD_AGENT_PAT }}
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+  security-events: write
+
+jobs:
+  audit:
+    name: Audit organization or repository
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: edfi-repo-auditor
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install Python 3.9
+        uses: actions/setup-python@98f2ad02fd48d057ee3b4d4f66525b231c3e52b6 # v3.1.2
+        with:
+          python-version: "3.9"
+          cache: "poetry"
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Audit
+        if: github.event.inputs.repository != ''
+        run: poetry run python edfi_repo_auditor -p ${{ env.PERSONAL_ACCESS_TOKEN }} -s -o ${{ github.event.inputs.organization }} -r ${{ github.event.inputs.repository }}
+
+      - name: Audit
+        if: github.event.inputs.repository == ''
+        run: poetry run python edfi_repo_auditor -p ${{ env.PERSONAL_ACCESS_TOKEN }} -s -o ${{ github.event.inputs.organization }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
+        with:
+          name: audit-result
+          path: ./edfi-repo-auditor/reports/audit-result.json
+          if-no-files-found: error
+          retention-days: 10

--- a/.github/workflows/run-single-audit.yml
+++ b/.github/workflows/run-single-audit.yml
@@ -64,7 +64,7 @@ jobs:
         run: poetry run python edfi_repo_auditor -p ${{ env.PERSONAL_ACCESS_TOKEN }} -s -o ${{ github.event.inputs.organization }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # v3.0.0
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: audit-result
           path: ./edfi-repo-auditor/reports/audit-result.json

--- a/edfi-repo-auditor/edfi_repo_auditor/checklist.py
+++ b/edfi-repo-auditor/edfi_repo_auditor/checklist.py
@@ -44,7 +44,7 @@ CHECKLIST = checklist(
               },
               APPROVED_ACTIONS={
                 "description": "Uses only approved GitHub Actions",
-                "fail": "Consider using only approved GH Actions"
+                "fail": "No. Consider using only approved GH Actions"
               },
               TEST_REPORTER={
                 "description": "Uses Test Reporter",

--- a/edfi-repo-auditor/edfi_repo_auditor/checklist.py
+++ b/edfi-repo-auditor/edfi_repo_auditor/checklist.py
@@ -60,19 +60,19 @@ CHECKLIST = checklist(
               },
               SIGNED_COMMITS={
                 "description": "Requires Signed commits",
-                "fail": "Commits should be signed"
+                "fail": "No. Commits should be signed"
               },
               CODE_REVIEW={
                 "description": "Requires Code review",
-                "fail": "Code review not required"
+                "fail": "Code reviews are not required"
               },
               REQUIRES_PR={
                 "description": "Requires PR",
-                "fail": "Can push without PR"
+                "fail": "Does not require PR"
               },
               ADMIN_PR={
                 "description": "Admin cannot bypass PR",
-                "fail": "Admin can bypass"
+                "fail": "Admin can bypass without PR"
               },
               WIKI={
                 "description": "Wiki Disabled",
@@ -92,11 +92,11 @@ CHECKLIST = checklist(
               },
               DELETES_HEAD={
                 "description": "Deletes head branch",
-                "fail": "Branch should be deleted on merge"
+                "fail": "No. Branch should be deleted on merge"
               },
               USES_SQUASH={
                 "description": "Uses Squash Merge",
-                "fail": "Should use squash merges"
+                "fail": "No. Should use squash merges"
               },
               LICENSE_INFORMATION={
                 "description": "License Information",


### PR DESCRIPTION
- Improve messages when audit got message.
- Creating workflow to run single audit for entire organization or single repo.
- Creating workflow to run full audit for all organizations manually and scheduled.
- Adding workflow to scan used actions