### PR TITLE
Repo Auditor: add job failure rate metric

### DIFF
--- a/docs/PRD-repository-auditor.md
+++ b/docs/PRD-repository-auditor.md
@@ -79,7 +79,7 @@ The `edfi-repo-auditor` is a Python CLI tool that programmatically audits one or
 - Repositories per organization: up to 100 (no cursor pagination yet; a warning is logged if the count exceeds 100).
 - Vulnerability alerts per repository: up to 100 (same limitation).
 - Pull requests with reviews: fully paginated with cursor; pagination exits early when the oldest PR on a page predates a 3× lookback window (default: 90 days back when `since_days=30`).
-- Workflow runs: fully paginated via REST `page`/`per_page`, bounded by the `created` filter (last 30 days) rather than a fixed page-count cap.
+- Workflow runs: fully paginated via REST `page`/`per_page`, bounded by the `created` filter (last 30 days) rather than a fixed page-count cap. The `actions/runs` endpoint itself caps combined pagination (`page * per_page`) at 1000 results and silently stops returning runs beyond that, even when `total_count` reports more — this would otherwise silently drop the oldest (and typically successful) runs for very active repositories, inflating the Job Failure Rate. When `total_count` exceeds 1000, `get_workflow_runs` re-fetches one calendar day at a time instead, since a single day's run count is expected to stay well under the cap.
 
 ### Output
 

--- a/docs/PRD-repository-auditor.md
+++ b/docs/PRD-repository-auditor.md
@@ -45,10 +45,11 @@ The `edfi-repo-auditor` is a Python CLI tool that programmatically audits one or
 33. As an Ed-Fi engineering manager, I want the tool to report average number of reviews and approvals per PR, so that I can assess review thoroughness.
 34. As an Ed-Fi engineering manager, I want the tool to report the share of reviews performed by the single most-active reviewer, so that I can detect unhealthy reviewer concentration.
 35. As an Ed-Fi engineering manager, I want the tool to report total and unique reviewer counts, so that I can understand the breadth of code-review participation.
-36. As a developer running the tool locally, I want to provide credentials and target configuration via environment variables, so that I do not need to repeat command-line arguments.
-37. As a developer running the tool locally, I want to disable SSL certificate verification for outbound requests, so that the tool works in environments with SSL inspection proxies.
-38. As a CI/CD pipeline operator, I want the audit summary written to the GitHub Actions job summary, so that results are visible directly in the workflow run UI.
-39. As a CI/CD pipeline operator, I want a non-zero exit code when a fatal error occurs, so that the workflow is marked failed and does not silently swallow errors.
+36. As an Ed-Fi engineering manager, I want the tool to report the Job Failure Rate for each repository's GitHub Actions workflows over the last 30 days, broken out per workflow, so that I can identify unreliable or flaky CI/CD pipelines.
+37. As a developer running the tool locally, I want to provide credentials and target configuration via environment variables, so that I do not need to repeat command-line arguments.
+38. As a developer running the tool locally, I want to disable SSL certificate verification for outbound requests, so that the tool works in environments with SSL inspection proxies.
+39. As a CI/CD pipeline operator, I want the audit summary written to the GitHub Actions job summary, so that results are visible directly in the workflow run UI.
+40. As a CI/CD pipeline operator, I want a non-zero exit code when a fatal error occurs, so that the workflow is marked failed and does not silently swallow errors.
 
 ## Implementation Decisions
 
@@ -58,6 +59,7 @@ The `edfi-repo-auditor` is a Python CLI tool that programmatically audits one or
 - **`github_client.py`** — Thin wrapper around the GitHub REST and GraphQL APIs. Handles authentication, error translation, GraphQL variable injection, and REST pagination. Branch-protection data is read from GraphQL *rulesets* (not the deprecated REST branch-protection endpoint).
 - **`auditor.py`** — Orchestration layer: calls all audit functions, merges their result dicts, invokes output helpers. Contains `audit_actions()`, `get_repo_information()`, `audit_alerts()`, `review_files()`, and `output_to_github_actions()`.
 - **`pr_metrics.py`** — Standalone module that computes all PR-related metrics. Receives pre-fetched PR data and returns plain dicts. Currently all metrics are informational (no pass/fail threshold).
+- **`job_metrics.py`** — Standalone module that computes the Job Failure Rate metric. Receives pre-fetched workflow-run data and returns plain dicts. Informational only (no pass/fail threshold).
 - **`ossf_score.py`** — Fetches the OpenSSF Scorecard score via the shields.io SVG badge endpoint, parses the score from the SVG `<title>` element using a regular expression.
 - **`checklist.py`** — Single source of truth for check names and failure messages, implemented as a named-tuple of dicts.
 - **`disable_tls.py`** — Context manager that monkey-patches `requests.Session` to skip TLS verification for all outbound calls within the block.
@@ -70,12 +72,14 @@ The `edfi-repo-auditor` is a Python CLI tool that programmatically audits one or
 - Dependabot alerts: GraphQL (included in the repository information query).
 - Pull requests and reviews: GraphQL (`PULL_REQUESTS_WITH_REVIEWS_TEMPLATE`) — single paginated query that fetches PRs and their embedded reviews in one call.
 - OSSF score: shields.io SVG badge (`img.shields.io/ossf-scorecard/github.com/{org}/{repo}`).
+- Workflow runs (for Job Failure Rate): REST (`/repos/{owner}/{repo}/actions/runs`), filtered server-side with the `created` query parameter to limit results to the last 30 days.
 
 ### Pagination Boundaries
 
 - Repositories per organization: up to 100 (no cursor pagination yet; a warning is logged if the count exceeds 100).
 - Vulnerability alerts per repository: up to 100 (same limitation).
 - Pull requests with reviews: fully paginated with cursor; pagination exits early when the oldest PR on a page predates a 3× lookback window (default: 90 days back when `since_days=30`).
+- Workflow runs: fully paginated via REST `page`/`per_page`, bounded by the `created` filter (last 30 days) rather than a fixed page-count cap.
 
 ### Output
 
@@ -86,6 +90,14 @@ The `edfi-repo-auditor` is a Python CLI tool that programmatically audits one or
 ### Scoring
 
 - `scoring.json` defines point values per checklist item and a passing threshold (currently 15 pts). This file is present in the repository but is **not yet wired into the runtime output**.
+
+### Job Failure Rate Metric
+
+- **Definition**: For each repository, the percentage of GitHub Actions workflow runs created in the last 30 days that concluded as a failure, computed per workflow (e.g., separately for "CI", "CodeQL", etc.) and also as an overall repository aggregate.
+- **Numerator**: runs with conclusion `failure`, `timed_out`, `action_required`, or `startup_failure`.
+- **Denominator**: numerator plus runs with conclusion `success`. Runs with conclusion `cancelled`, `skipped`, or `neutral` (and in-progress runs with no conclusion yet) are excluded from both numerator and denominator.
+- **Output keys**: `Job Failure Rate (%)` (overall), `Job Failure Rate - <workflow name> (%)` (per workflow), and `Total Workflow Runs (last 30 days)` (informational count).
+- **Scope**: informational only, consistent with PR metrics — no pass/fail threshold is applied.
 
 ## Testing Decisions
 
@@ -102,13 +114,14 @@ The `edfi-repo-auditor` is a Python CLI tool that programmatically audits one or
 - **`auditor.py`** audit functions: covered by `tests/auditor/` — one file per function (`test_audit_actions.py`, `test_audit_alerts.py`, `test_get_repo_information.py`, `test_review_files.py`).
 - **`ossf_score.py`**: covered by `tests/auditor/test_ossf_score.py` — tests for valid response, missing title, HTTP 404, HTTP 500.
 - **`pr_metrics.py`**: covered by `tests/pr_metrics/` — separate files for duration, review cycle, reviewer load balance, and the top-level `get_pr_metrics()` aggregator.
+- **`job_metrics.py`**: covered by `tests/job_metrics/` — tests for overall and per-workflow failure-rate calculation, conclusion filtering, and the top-level `get_job_failure_metrics()` aggregator.
 
 ## Out of Scope
 
 - **Scoring/thresholds for PR metrics**: all PR metrics are currently informational only; no pass/fail evaluation is performed.
 - **Repository pagination beyond 100**: organizations with more than 100 repositories will produce an incomplete audit and a log warning.
 - **Vulnerability-alert pagination beyond 100**: repositories with more than 100 open vulnerability alerts may produce incomplete results.
-- **CI health per PR** (pass rate, rerun count, average duration): not implemented.
+- **CI health per PR** (pass rate, rerun count, average duration, tied to a specific PR's commits): not implemented. The Job Failure Rate metric is repository/workflow-level, not linked to individual PRs.
 - **PR size indicators** (median additions/deletions/changed files): not implemented.
 - **Time-to-first-response** (first comment or review from non-author): not implemented.
 - **Security posture per PR** (PRs touching sensitive files, CodeQL-flagged PRs): not implemented.

--- a/edfi-repo-auditor/CLAUDE.md
+++ b/edfi-repo-auditor/CLAUDE.md
@@ -6,6 +6,7 @@ Data flows: `config.py` → `github_client.py` → `auditor.py` → CSV / GitHub
 
 - **`github_client.py`**: Branch protection rules use GraphQL *rulesets*, not the legacy REST branch-protection API.
 - **`pr_metrics.py`**: All PR metrics are informational only — no pass/fail thresholds.
+- **`job_metrics.py`**: Computes the Job Failure Rate (overall and per-workflow) from GitHub Actions workflow runs. Informational only — no pass/fail thresholds.
 - **`ossf_score.py`**: Fetches the OSSF Scorecard score by parsing the score out of a shields.io SVG badge `<title>`.
 
 ## Test Conventions

--- a/edfi-repo-auditor/README.md
+++ b/edfi-repo-auditor/README.md
@@ -98,3 +98,9 @@ Look in the `reports` directory for the output file.
 - **Avg Time to First Approval (hours)**: The average time to first approval in hours. Monitoring for trends, no baseline requirement _yet_.
 - **Top Reviewer Share (%)**: The percentage of reviews performed by the top reviewer. Monitor to make sure the burden is not falling primarily on one person.
 - **Unique Reviewers**: The total number of unique reviewers who have participated in the repository. Just informational.
+
+### Workflow Reliability Metrics
+
+- **Job Failure Rate (%)**: The percentage of GitHub Actions workflow runs in the last 30 days that concluded as a failure (`failure`, `timed_out`, `action_required`, or `startup_failure`), out of runs that concluded as either a failure or a `success`. Runs that were `cancelled`, `skipped`, or `neutral` are excluded. Just informational, no baseline requirement _yet_.
+- **Job Failure Rate - `<workflow name>` (%)**: The same calculation broken out per workflow (e.g., a separate rate for "CI" vs. "CodeQL"), so unreliable pipelines can be identified individually.
+- **Total Workflow Runs (last 30 days)**: The count of workflow runs included in the failure-rate calculation. Just informational.

--- a/edfi-repo-auditor/README.md
+++ b/edfi-repo-auditor/README.md
@@ -101,6 +101,6 @@ Look in the `reports` directory for the output file.
 
 ### Workflow Reliability Metrics
 
-- **Job Failure Rate (%)**: The percentage of GitHub Actions workflow runs in the last 30 days that concluded as a failure (`failure`, `timed_out`, `action_required`, or `startup_failure`), out of runs that concluded as either a failure or a `success`. Runs that were `cancelled`, `skipped`, or `neutral` are excluded. Just informational, no baseline requirement _yet_.
-- **Job Failure Rate - `<workflow name>` (%)**: The same calculation broken out per workflow (e.g., a separate rate for "CI" vs. "CodeQL"), so unreliable pipelines can be identified individually.
+- **Job Failure Rate (%)**: The percentage of GitHub Actions workflow runs in the last 30 days that concluded as a failure (`failure`, `timed_out`, `action_required`, or `startup_failure`), out of runs that concluded as either a failure or a `success`. Runs that were `cancelled`, `skipped`, or `neutral` are excluded. Just informational, no baseline requirement _yet_. Shows "N/A (no data)" when there are no countable runs in the window.
+- **Job Failure Rate - `<workflow name>` (%)**: The same calculation broken out per workflow (e.g., a separate rate for "CI" vs. "CodeQL"), so unreliable pipelines can be identified individually. Runs are grouped by the workflow's display name, not its file path, so renaming a workflow file mid-window — or two workflow files sharing the same display name — will merge or split history under that name. A run with a missing name is grouped under "Unknown".
 - **Total Workflow Runs (last 30 days)**: The count of workflow runs included in the failure-rate calculation. Just informational.

--- a/edfi-repo-auditor/edfi_repo_auditor/auditor.py
+++ b/edfi-repo-auditor/edfi_repo_auditor/auditor.py
@@ -65,7 +65,14 @@ def run_audit(config: Configuration) -> None:
         logger.debug(f"Files: {file_review}")
         pr_metrics = get_pr_metrics(client, config.organization, repository)
         logger.debug(f"PR Metrics: {pr_metrics}")
-        job_metrics = get_job_failure_metrics(client, organization, repository)
+        try:
+            job_metrics = get_job_failure_metrics(client, organization, repository)
+        except RuntimeError as e:
+            logger.warning(
+                f"Failed to compute job failure rate metrics for "
+                f"{organization}/{repository}: {e}"
+            )
+            job_metrics = {}
         logger.debug(f"Job Failure Rate Metrics: {job_metrics}")
         ossf_score = get_ossf_score(organization, repository)
         logger.debug(f"OpenSSF Score: {ossf_score}")
@@ -319,7 +326,8 @@ def output_to_github_actions(repository: str, results: dict) -> None:
 """
 
     for check, result in results.items():
-        summary += f"| {check} | {result} |\n"
+        display_result = "N/A (no data)" if result is None else result
+        summary += f"| {check} | {display_result} |\n"
 
     # Write to job summary
     if github_step_summary:

--- a/edfi-repo-auditor/edfi_repo_auditor/auditor.py
+++ b/edfi-repo-auditor/edfi_repo_auditor/auditor.py
@@ -22,6 +22,7 @@ from edfi_repo_auditor.checklist import (
 )
 from edfi_repo_auditor.config import Configuration
 from edfi_repo_auditor.github_client import GitHubClient
+from edfi_repo_auditor.job_metrics import get_job_failure_metrics
 from edfi_repo_auditor.ossf_score import get_ossf_score
 from edfi_repo_auditor.pr_metrics import get_pr_metrics
 
@@ -64,10 +65,19 @@ def run_audit(config: Configuration) -> None:
         logger.debug(f"Files: {file_review}")
         pr_metrics = get_pr_metrics(client, config.organization, repository)
         logger.debug(f"PR Metrics: {pr_metrics}")
+        job_metrics = get_job_failure_metrics(client, organization, repository)
+        logger.debug(f"Job Failure Rate Metrics: {job_metrics}")
         ossf_score = get_ossf_score(organization, repository)
         logger.debug(f"OpenSSF Score: {ossf_score}")
 
-        results = {**ossf_score, **actions, **file_review, **repo_config, **pr_metrics}
+        results = {
+            **ossf_score,
+            **actions,
+            **file_review,
+            **repo_config,
+            **pr_metrics,
+            **job_metrics,
+        }
 
         output_to_github_actions(repository, results)
 

--- a/edfi-repo-auditor/edfi_repo_auditor/github_client.py
+++ b/edfi-repo-auditor/edfi_repo_auditor/github_client.py
@@ -5,7 +5,7 @@
 
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from json import dumps
 
 import base64
@@ -451,14 +451,51 @@ class GitHubClient:
             "%Y-%m-%d"
         )
 
+        runs, total_count = self._fetch_workflow_run_pages(
+            owner, repository, f">={cutoff}", per_page
+        )
+
+        # The actions/runs endpoint caps combined pagination (page * per_page)
+        # at 1000 results and silently stops returning runs beyond that, even
+        # though `total_count` reports the true (larger) total. When that
+        # happens, the single windowed query above has silently dropped the
+        # oldest runs in the window, so re-fetch one calendar day at a time
+        # instead -- each day's result set stays comfortably under the cap.
+        if total_count is not None and total_count > 1000:
+            logger.warning(
+                f"{owner}/{repository} has {total_count} workflow runs in the "
+                f"last {since_days} days, which exceeds the GitHub API's "
+                "pagination limit; re-fetching one day at a time"
+            )
+            today = datetime.now(timezone.utc).date()
+            runs = []
+            for days_ago in range(since_days, -1, -1):
+                day = (today - timedelta(days=days_ago)).strftime("%Y-%m-%d")
+                day_runs, _ = self._fetch_workflow_run_pages(
+                    owner, repository, day, per_page
+                )
+                runs.extend(day_runs)
+
+        return runs
+
+    def _fetch_workflow_run_pages(
+        self, owner: str, repository: str, created_filter: str, per_page: int
+    ) -> Tuple[List[dict], Optional[int]]:
+        """
+        Fetch all pages of workflow runs matching a `created` query filter.
+
+        Returns a tuple of (runs, total_count), where total_count is the
+        value reported on the first page (or None if the API omitted it).
+        """
         all_runs: List[dict] = []
+        total_count: Optional[int] = None
         page = 1
 
         while True:
             logger.info(f"Getting workflow runs for {owner}/{repository}, page {page}")
             url = (
                 f"{API_URL}/repos/{owner}/{repository}/actions/runs"
-                f"?created=>={cutoff}&per_page={per_page}&page={page}"
+                f"?created={created_filter}&per_page={per_page}&page={page}"
             )
 
             body = self._execute_api_call(
@@ -466,6 +503,9 @@ class GitHubClient:
                 "GET",
                 url,
             )
+
+            if page == 1:
+                total_count = body.get("total_count")
 
             runs = body.get("workflow_runs", [])
             if not runs:
@@ -486,7 +526,7 @@ class GitHubClient:
 
             page += 1
 
-        return all_runs
+        return all_runs, total_count
 
     def get_merged_prs_with_reviews(
         self, owner: str, repository: str, since_days: int = 30

--- a/edfi-repo-auditor/edfi_repo_auditor/github_client.py
+++ b/edfi-repo-auditor/edfi_repo_auditor/github_client.py
@@ -4,7 +4,7 @@
 # See the LICENSE and NOTICES files in the project root for more information.
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 from json import dumps
 
@@ -421,6 +421,70 @@ class GitHubClient:
             page += 1
 
         return all_reviews
+
+    def get_workflow_runs(
+        self, owner: str, repository: str, since_days: int = 30, per_page: int = 100
+    ) -> List[dict]:
+        """
+        Get GitHub Actions workflow runs created within the last `since_days`
+        days, with full pagination.
+
+        Args:
+            owner: Repository owner
+            repository: Repository name
+            since_days: How many days back to fetch runs for. The `created`
+                        query parameter filters server-side so pagination
+                        naturally stops once older runs are reached.
+            per_page: Results per page (max 100)
+
+        Returns:
+            List of run records with name, conclusion, created_at, path
+        """
+        if len(owner.strip()) == 0:
+            raise ValueError("owner cannot be blank")
+        if len(repository.strip()) == 0:
+            raise ValueError("repository cannot be blank")
+
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=since_days)).strftime(
+            "%Y-%m-%d"
+        )
+
+        all_runs: List[dict] = []
+        page = 1
+
+        while True:
+            logger.info(f"Getting workflow runs for {owner}/{repository}, page {page}")
+            url = (
+                f"{API_URL}/repos/{owner}/{repository}/actions/runs"
+                f"?created=>={cutoff}&per_page={per_page}&page={page}"
+            )
+
+            body = self._execute_api_call(
+                f"Getting workflow runs for {owner}/{repository}",
+                "GET",
+                url,
+            )
+
+            runs = body.get("workflow_runs", [])
+            if not runs:
+                break
+
+            for run in runs:
+                all_runs.append(
+                    {
+                        "name": run.get("name"),
+                        "conclusion": run.get("conclusion"),
+                        "created_at": run.get("created_at"),
+                        "path": run.get("path"),
+                    }
+                )
+
+            if len(runs) < per_page:
+                break
+
+            page += 1
+
+        return all_runs
 
     def get_merged_prs_with_reviews(
         self, owner: str, repository: str, since_days: int = 30

--- a/edfi-repo-auditor/edfi_repo_auditor/github_client.py
+++ b/edfi-repo-auditor/edfi_repo_auditor/github_client.py
@@ -444,6 +444,8 @@ class GitHubClient:
             raise ValueError("owner cannot be blank")
         if len(repository.strip()) == 0:
             raise ValueError("repository cannot be blank")
+        if not 1 <= per_page <= 100:
+            raise ValueError("per_page must be between 1 and 100")
 
         cutoff = (datetime.now(timezone.utc) - timedelta(days=since_days)).strftime(
             "%Y-%m-%d"

--- a/edfi-repo-auditor/edfi_repo_auditor/job_metrics.py
+++ b/edfi-repo-auditor/edfi_repo_auditor/job_metrics.py
@@ -11,7 +11,7 @@ failure over the last 30 days, both overall and broken out per workflow.
 """
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List
 
 from edfi_repo_auditor.github_client import GitHubClient
@@ -31,6 +31,12 @@ TOTAL_WORKFLOW_RUNS_KEY = "Total Workflow Runs (last 30 days)"
 
 
 def _job_failure_rate_key(workflow_name: str) -> str:
+    """
+    Note: two runs with the same display `name` are grouped under one key
+    even if they come from different workflow files (or from a workflow
+    that was renamed mid-window), since GitHub Actions run names are not
+    guaranteed unique.
+    """
     return f"Job Failure Rate - {workflow_name} (%)"
 
 
@@ -108,6 +114,10 @@ def get_job_failure_metrics(
     now_utc = datetime.now(timezone.utc)
     runs = client.get_workflow_runs(owner, repository, since_days=LAST_N_DAYS)
 
+    # get_workflow_runs already filters server-side via the `created` query
+    # parameter, but that cutoff has only day-level granularity, so it can
+    # return runs up to ~24h older than the true window. Re-filter here with
+    # an exact timedelta comparison to enforce the precise boundary.
     recent_runs: List[Dict] = []
     for run in runs:
         created_at_str = run.get("created_at")
@@ -119,7 +129,7 @@ def get_job_failure_metrics(
             )
         except (ValueError, AttributeError):
             continue
-        if (now_utc - created_at).days > LAST_N_DAYS:
+        if now_utc - created_at > timedelta(days=LAST_N_DAYS):
             continue
         recent_runs.append(run)
 

--- a/edfi-repo-auditor/edfi_repo_auditor/job_metrics.py
+++ b/edfi-repo-auditor/edfi_repo_auditor/job_metrics.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+"""
+Job Failure Rate metrics module.
+
+Computes the percentage of GitHub Actions workflow runs that concluded as a
+failure over the last 30 days, both overall and broken out per workflow.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Dict, List
+
+from edfi_repo_auditor.github_client import GitHubClient
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+LAST_N_DAYS = 30
+
+# Conclusions that count as a failed run.
+FAILURE_CONCLUSIONS = {"failure", "timed_out", "action_required", "startup_failure"}
+
+# Conclusions that count as a successful run.
+SUCCESS_CONCLUSIONS = {"success"}
+
+JOB_FAILURE_RATE_KEY = "Job Failure Rate (%)"
+TOTAL_WORKFLOW_RUNS_KEY = "Total Workflow Runs (last 30 days)"
+
+
+def _job_failure_rate_key(workflow_name: str) -> str:
+    return f"Job Failure Rate - {workflow_name} (%)"
+
+
+def audit_job_failure_rate(runs: List[Dict]) -> Dict[str, object]:
+    """
+    Compute the Job Failure Rate, overall and per workflow.
+
+    Only runs with conclusion in FAILURE_CONCLUSIONS or SUCCESS_CONCLUSIONS
+    are counted; runs with conclusion "cancelled", "skipped", "neutral", or
+    no conclusion (still in progress) are excluded from both the numerator
+    and the denominator.
+
+    Args:
+        runs: List of workflow run dicts, each with "name" and "conclusion"
+
+    Returns:
+        Dictionary with:
+        - Job Failure Rate (%): overall failure rate (float or None if no
+          countable runs)
+        - Job Failure Rate - <workflow name> (%): failure rate per workflow
+        - Total Workflow Runs (last 30 days): count of countable runs
+    """
+    counted_runs = [
+        run
+        for run in runs
+        if run.get("conclusion") in FAILURE_CONCLUSIONS
+        or run.get("conclusion") in SUCCESS_CONCLUSIONS
+    ]
+
+    result: Dict[str, object] = {
+        TOTAL_WORKFLOW_RUNS_KEY: len(counted_runs),
+    }
+
+    if not counted_runs:
+        result[JOB_FAILURE_RATE_KEY] = None
+        return result
+
+    total_failures = sum(
+        1 for run in counted_runs if run["conclusion"] in FAILURE_CONCLUSIONS
+    )
+    result[JOB_FAILURE_RATE_KEY] = round((total_failures / len(counted_runs)) * 100, 2)
+
+    runs_by_workflow: Dict[str, List[Dict]] = {}
+    for run in counted_runs:
+        workflow_name = run.get("name") or "Unknown"
+        runs_by_workflow.setdefault(workflow_name, []).append(run)
+
+    for workflow_name, workflow_runs in runs_by_workflow.items():
+        failures = sum(
+            1 for run in workflow_runs if run["conclusion"] in FAILURE_CONCLUSIONS
+        )
+        result[_job_failure_rate_key(workflow_name)] = round(
+            (failures / len(workflow_runs)) * 100, 2
+        )
+
+    return result
+
+
+def get_job_failure_metrics(
+    client: GitHubClient, owner: str, repository: str
+) -> Dict[str, object]:
+    """
+    Get Job Failure Rate metrics for a repository.
+
+    Args:
+        client: GitHubClient instance
+        owner: Repository owner
+        repository: Repository name
+
+    Returns:
+        Dictionary with Job Failure Rate metrics; see audit_job_failure_rate.
+    """
+    logger.info(f"Computing job failure rate metrics for {owner}/{repository}")
+
+    now_utc = datetime.now(timezone.utc)
+    runs = client.get_workflow_runs(owner, repository, since_days=LAST_N_DAYS)
+
+    recent_runs: List[Dict] = []
+    for run in runs:
+        created_at_str = run.get("created_at")
+        if created_at_str is None:
+            continue
+        try:
+            created_at = datetime.fromisoformat(
+                str(created_at_str).replace("Z", "+00:00")
+            )
+        except (ValueError, AttributeError):
+            continue
+        if (now_utc - created_at).days > LAST_N_DAYS:
+            continue
+        recent_runs.append(run)
+
+    return audit_job_failure_rate(recent_runs)

--- a/edfi-repo-auditor/tests/auditor/test_run_audit.py
+++ b/edfi-repo-auditor/tests/auditor/test_run_audit.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+from unittest.mock import patch
+
+from edfi_repo_auditor.auditor import run_audit
+from edfi_repo_auditor.config import Configuration
+
+ACCESS_TOKEN = "asd09uasdfu09asdfj;iolkasdfklj"
+OWNER = "Ed-Fi-Alliance-OSS"
+REPO = "Ed-Fi-ODS"
+OTHER_REPO = "Ed-Fi-Admin"
+
+
+def _config(repositories: list) -> Configuration:
+    return Configuration(
+        organization=OWNER,
+        personal_access_token=ACCESS_TOKEN,
+        repositories=repositories,
+        log_level="INFO",
+        save_results=False,
+        file_name="",
+    )
+
+
+def describe_when_running_a_full_audit() -> None:
+    def describe_given_all_audits_succeed() -> None:
+        @patch("edfi_repo_auditor.auditor.output_to_github_actions")
+        @patch("edfi_repo_auditor.auditor.get_ossf_score")
+        @patch("edfi_repo_auditor.auditor.get_job_failure_metrics")
+        @patch("edfi_repo_auditor.auditor.get_pr_metrics")
+        @patch("edfi_repo_auditor.auditor.review_files")
+        @patch("edfi_repo_auditor.auditor.audit_actions")
+        @patch("edfi_repo_auditor.auditor.get_repo_information")
+        @patch("edfi_repo_auditor.auditor.GitHubClient")
+        def it_merges_job_failure_metrics_into_the_results_without_collisions(
+            mock_client_class,
+            mock_repo_info,
+            mock_actions,
+            mock_files,
+            mock_pr_metrics,
+            mock_job_metrics,
+            mock_ossf,
+            mock_output,
+        ) -> None:
+            mock_repo_info.return_value = {"Repo Check": "pass"}
+            mock_actions.return_value = {"Actions Check": "pass"}
+            mock_files.return_value = {"Files Check": "pass"}
+            mock_pr_metrics.return_value = {"Avg PR Duration (days)": 1.0}
+            mock_job_metrics.return_value = {
+                "Job Failure Rate (%)": 25.0,
+                "Total Workflow Runs (last 30 days)": 4,
+            }
+            mock_ossf.return_value = {"OSSF Score": 8.0}
+
+            run_audit(_config([REPO]))
+
+            results = mock_output.call_args[0][1]
+            assert results["Job Failure Rate (%)"] == 25.0
+            assert results["Total Workflow Runs (last 30 days)"] == 4
+            assert results["Repo Check"] == "pass"
+            assert results["Actions Check"] == "pass"
+            assert results["Files Check"] == "pass"
+            assert results["Avg PR Duration (days)"] == 1.0
+            assert results["OSSF Score"] == 8.0
+
+    def describe_given_job_failure_metrics_raises_a_runtime_error_for_one_repository() -> (  # noqa: E501
+        None
+    ):
+        @patch("edfi_repo_auditor.auditor.output_to_github_actions")
+        @patch("edfi_repo_auditor.auditor.get_ossf_score")
+        @patch("edfi_repo_auditor.auditor.get_job_failure_metrics")
+        @patch("edfi_repo_auditor.auditor.get_pr_metrics")
+        @patch("edfi_repo_auditor.auditor.review_files")
+        @patch("edfi_repo_auditor.auditor.audit_actions")
+        @patch("edfi_repo_auditor.auditor.get_repo_information")
+        @patch("edfi_repo_auditor.auditor.GitHubClient")
+        def it_still_produces_results_for_the_other_repository(
+            mock_client_class,
+            mock_repo_info,
+            mock_actions,
+            mock_files,
+            mock_pr_metrics,
+            mock_job_metrics,
+            mock_ossf,
+            mock_output,
+        ) -> None:
+            mock_repo_info.return_value = {}
+            mock_actions.return_value = {}
+            mock_files.return_value = {}
+            mock_pr_metrics.return_value = {}
+            mock_job_metrics.side_effect = [
+                RuntimeError("boom"),
+                {
+                    "Job Failure Rate (%)": 0.0,
+                    "Total Workflow Runs (last 30 days)": 2,
+                },
+            ]
+            mock_ossf.return_value = {}
+
+            run_audit(_config([REPO, OTHER_REPO]))
+
+            assert mock_output.call_count == 2
+
+            first_results = mock_output.call_args_list[0][0][1]
+            second_results = mock_output.call_args_list[1][0][1]
+
+            assert "Job Failure Rate (%)" not in first_results
+            assert second_results["Job Failure Rate (%)"] == 0.0
+            assert second_results["Total Workflow Runs (last 30 days)"] == 2

--- a/edfi-repo-auditor/tests/github_client/test_get_merged_prs_with_reviews.py
+++ b/edfi-repo-auditor/tests/github_client/test_get_merged_prs_with_reviews.py
@@ -35,12 +35,19 @@ def _graphql_response(nodes, has_next_page=False, end_cursor=None):
 
 def _make_node(
     number,
-    created_at="2026-03-20T10:00:00Z",
-    merged_at="2026-03-21T10:00:00Z",
-    closed_at="2026-03-21T10:00:00Z",
+    created_at=None,
+    merged_at=None,
+    closed_at=None,
     author_login="alice",
     reviews=None,
 ):
+    now = datetime.now(timezone.utc)
+    if created_at is None:
+        created_at = (now - timedelta(days=1)).strftime(_ISO)
+    if merged_at is None:
+        merged_at = now.strftime(_ISO)
+    if closed_at is None:
+        closed_at = now.strftime(_ISO)
     return {
         "number": number,
         "createdAt": created_at,
@@ -92,7 +99,17 @@ def describe_get_merged_prs_with_reviews() -> None:
             with requests_mock_module.Mocker() as m:
                 m.post(
                     GRAPHQL_ENDPOINT,
-                    json=_graphql_response([_make_node(42, reviews=[REVIEW_NODE])]),
+                    json=_graphql_response(
+                        [
+                            _make_node(
+                                42,
+                                created_at="2026-03-20T10:00:00Z",
+                                merged_at="2026-03-21T10:00:00Z",
+                                closed_at="2026-03-21T10:00:00Z",
+                                reviews=[REVIEW_NODE],
+                            )
+                        ]
+                    ),
                 )
                 return GitHubClient(ACCESS_TOKEN).get_merged_prs_with_reviews(
                     OWNER, REPO
@@ -126,13 +143,28 @@ def describe_get_merged_prs_with_reviews() -> None:
             assert results[0]["reviews"][0]["submitted_at"] == "2026-03-21T09:00:00Z"
 
     def describe_given_multiple_pages() -> None:
+        now = datetime.now(timezone.utc)
         PAGE1 = _graphql_response(
-            [_make_node(2, created_at="2026-03-25T10:00:00Z")],
+            [
+                _make_node(
+                    2,
+                    created_at=(now - timedelta(days=2)).strftime(_ISO),
+                    merged_at=(now - timedelta(days=1)).strftime(_ISO),
+                    closed_at=(now - timedelta(days=1)).strftime(_ISO),
+                )
+            ],
             has_next_page=True,
             end_cursor="cursor_abc",
         )
         PAGE2 = _graphql_response(
-            [_make_node(1, created_at="2026-03-20T10:00:00Z")],
+            [
+                _make_node(
+                    1,
+                    created_at=(now - timedelta(days=3)).strftime(_ISO),
+                    merged_at=(now - timedelta(days=2)).strftime(_ISO),
+                    closed_at=(now - timedelta(days=2)).strftime(_ISO),
+                )
+            ],
             has_next_page=False,
         )
 

--- a/edfi-repo-auditor/tests/github_client/test_get_workflow_runs.py
+++ b/edfi-repo-auditor/tests/github_client/test_get_workflow_runs.py
@@ -34,6 +34,19 @@ def describe_when_getting_workflow_runs() -> None:
             with pytest.raises(ValueError):
                 GitHubClient(ACCESS_TOKEN).get_workflow_runs(OWNER, "")
 
+    def describe_given_an_out_of_range_per_page() -> None:
+        def it_raises_a_ValueError_when_zero() -> None:
+            with pytest.raises(ValueError):
+                GitHubClient(ACCESS_TOKEN).get_workflow_runs(OWNER, REPO, per_page=0)
+
+        def it_raises_a_ValueError_when_negative() -> None:
+            with pytest.raises(ValueError):
+                GitHubClient(ACCESS_TOKEN).get_workflow_runs(OWNER, REPO, per_page=-1)
+
+        def it_raises_a_ValueError_when_over_100() -> None:
+            with pytest.raises(ValueError):
+                GitHubClient(ACCESS_TOKEN).get_workflow_runs(OWNER, REPO, per_page=101)
+
     def describe_given_valid_information() -> None:
         def describe_given_single_page_of_runs() -> None:
             RUNS_RESULT = """
@@ -127,6 +140,48 @@ def describe_when_getting_workflow_runs() -> None:
 
             def it_returns_all_three_runs(results: list) -> None:
                 assert len(results) == 3
+
+        def describe_given_a_final_page_exactly_equal_to_per_page() -> None:
+            FULL_PAGE_RESULT = """
+{
+    "workflow_runs": [
+        {
+            "name": "CI",
+            "conclusion": "success",
+            "created_at": "2024-01-01T10:00:00Z",
+            "path": ".github/workflows/ci.yml"
+        },
+        {
+            "name": "CI",
+            "conclusion": "failure",
+            "created_at": "2024-01-02T10:00:00Z",
+            "path": ".github/workflows/ci.yml"
+        }
+    ]
+}
+""".strip()
+
+            @pytest.fixture
+            def results() -> list:
+                with requests_mock.Mocker() as m:
+                    m.get(
+                        f"{RUNS_URL}?created=>={_cutoff()}&per_page=2&page=1",
+                        status_code=HTTPStatus.OK,
+                        text=FULL_PAGE_RESULT,
+                    )
+                    m.get(
+                        f"{RUNS_URL}?created=>={_cutoff()}&per_page=2&page=2",
+                        status_code=HTTPStatus.OK,
+                        text='{"workflow_runs": []}',
+                    )
+                    return GitHubClient(ACCESS_TOKEN).get_workflow_runs(
+                        OWNER, REPO, per_page=2
+                    )
+
+            def it_fetches_the_trailing_empty_page_and_returns_two_runs(
+                results: list,
+            ) -> None:
+                assert len(results) == 2
 
         def describe_given_empty_result() -> None:
             @pytest.fixture

--- a/edfi-repo-auditor/tests/github_client/test_get_workflow_runs.py
+++ b/edfi-repo-auditor/tests/github_client/test_get_workflow_runs.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
+
+import pytest
+import requests_mock
+
+from edfi_repo_auditor.github_client import GitHubClient, API_URL
+
+ACCESS_TOKEN = "asd09uasdfu09asdfj;iolkasdfklj"
+OWNER = "Ed-Fi-Alliance-OSS"
+REPO = "Ed-Fi-ODS"
+RUNS_URL = f"{API_URL}/repos/{OWNER}/{REPO}/actions/runs"
+
+
+def _cutoff(since_days: int = 30) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=since_days)).strftime(
+        "%Y-%m-%d"
+    )
+
+
+def describe_when_getting_workflow_runs() -> None:
+    def describe_given_blank_owner() -> None:
+        def it_raises_a_ValueError() -> None:
+            with pytest.raises(ValueError):
+                GitHubClient(ACCESS_TOKEN).get_workflow_runs("", REPO)
+
+    def describe_given_blank_repository() -> None:
+        def it_raises_a_ValueError() -> None:
+            with pytest.raises(ValueError):
+                GitHubClient(ACCESS_TOKEN).get_workflow_runs(OWNER, "")
+
+    def describe_given_valid_information() -> None:
+        def describe_given_single_page_of_runs() -> None:
+            RUNS_RESULT = """
+{
+    "workflow_runs": [
+        {
+            "name": "CI",
+            "conclusion": "success",
+            "created_at": "2024-01-01T10:00:00Z",
+            "path": ".github/workflows/ci.yml"
+        },
+        {
+            "name": "CodeQL",
+            "conclusion": "failure",
+            "created_at": "2024-01-02T10:00:00Z",
+            "path": ".github/workflows/codeql.yml"
+        }
+    ]
+}
+""".strip()
+
+            @pytest.fixture
+            def results() -> list:
+                with requests_mock.Mocker() as m:
+                    m.get(
+                        f"{RUNS_URL}?created=>={_cutoff()}&per_page=100&page=1",
+                        status_code=HTTPStatus.OK,
+                        text=RUNS_RESULT,
+                    )
+                    return GitHubClient(ACCESS_TOKEN).get_workflow_runs(OWNER, REPO)
+
+            def it_returns_two_runs(results: list) -> None:
+                assert len(results) == 2
+
+            def it_returns_correct_first_run_name(results: list) -> None:
+                assert results[0]["name"] == "CI"
+
+            def it_returns_correct_conclusion(results: list) -> None:
+                assert results[0]["conclusion"] == "success"
+                assert results[1]["conclusion"] == "failure"
+
+        def describe_given_multiple_pages_of_runs() -> None:
+            PAGE1_RESULT = """
+{
+    "workflow_runs": [
+        {
+            "name": "CI",
+            "conclusion": "success",
+            "created_at": "2024-01-01T10:00:00Z",
+            "path": ".github/workflows/ci.yml"
+        },
+        {
+            "name": "CI",
+            "conclusion": "failure",
+            "created_at": "2024-01-02T10:00:00Z",
+            "path": ".github/workflows/ci.yml"
+        }
+    ]
+}
+""".strip()
+
+            PAGE2_RESULT = """
+{
+    "workflow_runs": [
+        {
+            "name": "CI",
+            "conclusion": "success",
+            "created_at": "2024-01-03T10:00:00Z",
+            "path": ".github/workflows/ci.yml"
+        }
+    ]
+}
+""".strip()
+
+            @pytest.fixture
+            def results() -> list:
+                with requests_mock.Mocker() as m:
+                    m.get(
+                        f"{RUNS_URL}?created=>={_cutoff()}&per_page=2&page=1",
+                        status_code=HTTPStatus.OK,
+                        text=PAGE1_RESULT,
+                    )
+                    m.get(
+                        f"{RUNS_URL}?created=>={_cutoff()}&per_page=2&page=2",
+                        status_code=HTTPStatus.OK,
+                        text=PAGE2_RESULT,
+                    )
+                    return GitHubClient(ACCESS_TOKEN).get_workflow_runs(
+                        OWNER, REPO, per_page=2
+                    )
+
+            def it_returns_all_three_runs(results: list) -> None:
+                assert len(results) == 3
+
+        def describe_given_empty_result() -> None:
+            @pytest.fixture
+            def results() -> list:
+                with requests_mock.Mocker() as m:
+                    m.get(
+                        f"{RUNS_URL}?created=>={_cutoff()}&per_page=100&page=1",
+                        status_code=HTTPStatus.OK,
+                        text='{"workflow_runs": []}',
+                    )
+                    return GitHubClient(ACCESS_TOKEN).get_workflow_runs(OWNER, REPO)
+
+            def it_returns_empty_list(results: list) -> None:
+                assert results == []
+
+        def describe_given_internal_server_error() -> None:
+            def it_raises_a_RuntimeError() -> None:
+                with requests_mock.Mocker() as m:
+                    m.get(
+                        f"{RUNS_URL}?created=>={_cutoff()}&per_page=100&page=1",
+                        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                        text="{}",
+                    )
+                    with pytest.raises(RuntimeError):
+                        GitHubClient(ACCESS_TOKEN).get_workflow_runs(OWNER, REPO)

--- a/edfi-repo-auditor/tests/github_client/test_get_workflow_runs.py
+++ b/edfi-repo-auditor/tests/github_client/test_get_workflow_runs.py
@@ -207,3 +207,76 @@ def describe_when_getting_workflow_runs() -> None:
                     )
                     with pytest.raises(RuntimeError):
                         GitHubClient(ACCESS_TOKEN).get_workflow_runs(OWNER, REPO)
+
+        def describe_given_total_count_exceeds_the_1000_result_pagination_cap() -> None:
+            # GitHub's actions/runs endpoint silently stops returning results
+            # once page * per_page exceeds 1000, even when total_count says
+            # more runs exist. When that's detected, the client re-fetches one
+            # calendar day at a time instead of trusting the windowed query.
+            def it_falls_back_to_per_day_fetching() -> None:
+                today = datetime.now(timezone.utc).date()
+                yesterday_str = (today - timedelta(days=1)).strftime("%Y-%m-%d")
+                today_str = today.strftime("%Y-%m-%d")
+
+                WINDOWED_RESULT = """
+{
+    "total_count": 1500,
+    "workflow_runs": [
+        {
+            "name": "CI",
+            "conclusion": "success",
+            "created_at": "2024-01-01T10:00:00Z",
+            "path": ".github/workflows/ci.yml"
+        }
+    ]
+}
+""".strip()
+
+                DAY1_RESULT = f"""
+{{
+    "workflow_runs": [
+        {{
+            "name": "CI",
+            "conclusion": "failure",
+            "created_at": "{yesterday_str}T09:00:00Z",
+            "path": ".github/workflows/ci.yml"
+        }}
+    ]
+}}
+""".strip()
+
+                DAY2_RESULT = f"""
+{{
+    "workflow_runs": [
+        {{
+            "name": "CI",
+            "conclusion": "success",
+            "created_at": "{today_str}T09:00:00Z",
+            "path": ".github/workflows/ci.yml"
+        }}
+    ]
+}}
+""".strip()
+
+                with requests_mock.Mocker() as m:
+                    m.get(
+                        f"{RUNS_URL}?created=>={_cutoff(1)}&per_page=100&page=1",
+                        status_code=HTTPStatus.OK,
+                        text=WINDOWED_RESULT,
+                    )
+                    m.get(
+                        f"{RUNS_URL}?created={yesterday_str}&per_page=100&page=1",
+                        status_code=HTTPStatus.OK,
+                        text=DAY1_RESULT,
+                    )
+                    m.get(
+                        f"{RUNS_URL}?created={today_str}&per_page=100&page=1",
+                        status_code=HTTPStatus.OK,
+                        text=DAY2_RESULT,
+                    )
+                    results = GitHubClient(ACCESS_TOKEN).get_workflow_runs(
+                        OWNER, REPO, since_days=1
+                    )
+
+                assert len(results) == 2
+                assert {r["conclusion"] for r in results} == {"failure", "success"}

--- a/edfi-repo-auditor/tests/job_metrics/__init__.py
+++ b/edfi-repo-auditor/tests/job_metrics/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.

--- a/edfi-repo-auditor/tests/job_metrics/test_audit_job_failure_rate.py
+++ b/edfi-repo-auditor/tests/job_metrics/test_audit_job_failure_rate.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+from typing import Dict, List
+
+from edfi_repo_auditor.job_metrics import (
+    JOB_FAILURE_RATE_KEY,
+    TOTAL_WORKFLOW_RUNS_KEY,
+    audit_job_failure_rate,
+)
+
+
+def _run(name: str, conclusion: str) -> Dict:
+    return {"name": name, "conclusion": conclusion}
+
+
+def describe_audit_job_failure_rate() -> None:
+    def describe_given_no_runs() -> None:
+        def it_returns_none_rate_and_zero_total() -> None:
+            result = audit_job_failure_rate([])
+
+            assert result[JOB_FAILURE_RATE_KEY] is None
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 0
+
+    def describe_given_only_excluded_conclusions() -> None:
+        def it_returns_none_rate_and_zero_total() -> None:
+            runs: List[Dict] = [
+                _run("CI", "cancelled"),
+                _run("CI", "skipped"),
+                _run("CI", "neutral"),
+            ]
+
+            result = audit_job_failure_rate(runs)
+
+            assert result[JOB_FAILURE_RATE_KEY] is None
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 0
+
+    def describe_given_mixed_success_and_failure_runs() -> None:
+        def it_computes_overall_failure_rate() -> None:
+            runs: List[Dict] = [
+                _run("CI", "success"),
+                _run("CI", "success"),
+                _run("CI", "failure"),
+                _run("CI", "success"),
+            ]
+
+            result = audit_job_failure_rate(runs)
+
+            assert result[JOB_FAILURE_RATE_KEY] == 25.0
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 4
+
+        def it_excludes_cancelled_skipped_and_neutral_from_denominator() -> None:
+            runs: List[Dict] = [
+                _run("CI", "success"),
+                _run("CI", "failure"),
+                _run("CI", "cancelled"),
+                _run("CI", "skipped"),
+                _run("CI", "neutral"),
+            ]
+
+            result = audit_job_failure_rate(runs)
+
+            assert result[JOB_FAILURE_RATE_KEY] == 50.0
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 2
+
+    def describe_given_timed_out_action_required_and_startup_failure() -> None:
+        def it_counts_them_as_failures() -> None:
+            runs: List[Dict] = [
+                _run("CI", "success"),
+                _run("CI", "timed_out"),
+                _run("CI", "action_required"),
+                _run("CI", "startup_failure"),
+            ]
+
+            result = audit_job_failure_rate(runs)
+
+            assert result[JOB_FAILURE_RATE_KEY] == 75.0
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 4
+
+    def describe_given_multiple_workflows() -> None:
+        def it_computes_a_separate_rate_per_workflow() -> None:
+            runs: List[Dict] = [
+                _run("CI", "success"),
+                _run("CI", "failure"),
+                _run("CodeQL", "success"),
+                _run("CodeQL", "success"),
+            ]
+
+            result = audit_job_failure_rate(runs)
+
+            assert result["Job Failure Rate - CI (%)"] == 50.0
+            assert result["Job Failure Rate - CodeQL (%)"] == 0.0
+            assert result[JOB_FAILURE_RATE_KEY] == 25.0
+
+    def describe_given_run_with_missing_name() -> None:
+        def it_groups_under_unknown() -> None:
+            runs: List[Dict] = [
+                {"conclusion": "failure"},
+                {"conclusion": "success"},
+            ]
+
+            result = audit_job_failure_rate(runs)
+
+            assert result["Job Failure Rate - Unknown (%)"] == 50.0

--- a/edfi-repo-auditor/tests/job_metrics/test_audit_job_failure_rate.py
+++ b/edfi-repo-auditor/tests/job_metrics/test_audit_job_failure_rate.py
@@ -51,6 +51,18 @@ def describe_audit_job_failure_rate() -> None:
             assert result[JOB_FAILURE_RATE_KEY] == 25.0
             assert result[TOTAL_WORKFLOW_RUNS_KEY] == 4
 
+        def it_rounds_a_repeating_decimal_to_two_places() -> None:
+            runs: List[Dict] = [
+                _run("CI", "failure"),
+                _run("CI", "success"),
+                _run("CI", "success"),
+            ]
+
+            result = audit_job_failure_rate(runs)
+
+            assert result[JOB_FAILURE_RATE_KEY] == 33.33
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 3
+
         def it_excludes_cancelled_skipped_and_neutral_from_denominator() -> None:
             runs: List[Dict] = [
                 _run("CI", "success"),

--- a/edfi-repo-auditor/tests/job_metrics/test_get_job_failure_metrics.py
+++ b/edfi-repo-auditor/tests/job_metrics/test_get_job_failure_metrics.py
@@ -16,6 +16,9 @@ _now = datetime.now(timezone.utc)
 
 RECENT_CREATED_AT = (_now - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
 OLD_CREATED_AT = (_now - timedelta(days=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+JUST_PAST_BOUNDARY_CREATED_AT = (_now - timedelta(days=30, hours=1)).strftime(
+    "%Y-%m-%dT%H:%M:%SZ"
+)
 
 
 def _run(name: str, conclusion: str, created_at: str) -> dict:
@@ -65,6 +68,42 @@ def describe_get_job_failure_metrics() -> None:
             client = MagicMock()
             client.get_workflow_runs.return_value = [
                 {"name": "CI", "conclusion": "failure", "created_at": None},
+            ]
+
+            result = get_job_failure_metrics(client, "owner", "repo")
+
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 0
+
+    def describe_given_run_with_malformed_created_at() -> None:
+        def it_excludes_it_from_metrics() -> None:
+            client = MagicMock()
+            client.get_workflow_runs.return_value = [
+                {"name": "CI", "conclusion": "failure", "created_at": "not-a-date"},
+            ]
+
+            result = get_job_failure_metrics(client, "owner", "repo")
+
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 0
+
+    def describe_given_run_with_a_non_z_iso_offset() -> None:
+        def it_includes_it_in_metrics() -> None:
+            client = MagicMock()
+            recent_with_offset = (_now - timedelta(days=5)).strftime(
+                "%Y-%m-%dT%H:%M:%S+00:00"
+            )
+            client.get_workflow_runs.return_value = [
+                _run("CI", "failure", recent_with_offset),
+            ]
+
+            result = get_job_failure_metrics(client, "owner", "repo")
+
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 1
+
+    def describe_given_a_run_just_past_the_30_day_boundary() -> None:
+        def it_excludes_it_from_metrics() -> None:
+            client = MagicMock()
+            client.get_workflow_runs.return_value = [
+                _run("CI", "failure", JUST_PAST_BOUNDARY_CREATED_AT),
             ]
 
             result = get_job_failure_metrics(client, "owner", "repo")

--- a/edfi-repo-auditor/tests/job_metrics/test_get_job_failure_metrics.py
+++ b/edfi-repo-auditor/tests/job_metrics/test_get_job_failure_metrics.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from edfi_repo_auditor.job_metrics import (
+    JOB_FAILURE_RATE_KEY,
+    TOTAL_WORKFLOW_RUNS_KEY,
+    get_job_failure_metrics,
+)
+
+_now = datetime.now(timezone.utc)
+
+RECENT_CREATED_AT = (_now - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+OLD_CREATED_AT = (_now - timedelta(days=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _run(name: str, conclusion: str, created_at: str) -> dict:
+    return {"name": name, "conclusion": conclusion, "created_at": created_at}
+
+
+def describe_get_job_failure_metrics() -> None:
+    def describe_given_no_runs() -> None:
+        def it_returns_none_rate_and_zero_total() -> None:
+            client = MagicMock()
+            client.get_workflow_runs.return_value = []
+
+            result = get_job_failure_metrics(client, "owner", "repo")
+
+            assert result[JOB_FAILURE_RATE_KEY] is None
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 0
+
+    def describe_given_runs_older_than_30_days() -> None:
+        def it_excludes_them_from_metrics() -> None:
+            client = MagicMock()
+            client.get_workflow_runs.return_value = [
+                _run("CI", "failure", OLD_CREATED_AT),
+            ]
+
+            result = get_job_failure_metrics(client, "owner", "repo")
+
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 0
+
+    def describe_given_recent_runs() -> None:
+        def it_includes_them_in_metrics() -> None:
+            client = MagicMock()
+            client.get_workflow_runs.return_value = [
+                _run("CI", "success", RECENT_CREATED_AT),
+                _run("CI", "failure", RECENT_CREATED_AT),
+            ]
+
+            result = get_job_failure_metrics(client, "owner", "repo")
+
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 2
+            assert result[JOB_FAILURE_RATE_KEY] == 50.0
+            client.get_workflow_runs.assert_called_once_with(
+                "owner", "repo", since_days=30
+            )
+
+    def describe_given_run_with_missing_created_at() -> None:
+        def it_excludes_it_from_metrics() -> None:
+            client = MagicMock()
+            client.get_workflow_runs.return_value = [
+                {"name": "CI", "conclusion": "failure", "created_at": None},
+            ]
+
+            result = get_job_failure_metrics(client, "owner", "repo")
+
+            assert result[TOTAL_WORKFLOW_RUNS_KEY] == 0


### PR DESCRIPTION
Adds a new "job failure rate" metric for the audited repository

[Example](https://github.com/Ed-Fi-Alliance-OSS/DevSecOps/actions/runs/31216005739); I spot checked the new calculations for correctness.